### PR TITLE
fix the spark compute version to be 3.1

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -6603,7 +6603,7 @@
                         "nodeSizeFamily": "MemoryOptimized",
                         "sessionLevelPackagesEnabled": true,
                         "sparkEventsFolder": "events/",
-                        "sparkVersion": "3.0"
+                        "sparkVersion": "3.1"
                       },
                       "dependsOn": [
                         "[resourceId('Microsoft.Synapse/workspaces', parameters('synapseName'))]"


### PR DESCRIPTION
Deployment failed because the spark version is specified as 3.0 which is no longer a valid version.
The error message was: "Spark pool request validation failed." -- "InvalidSparkComputeVersion" -- "Spark Compute version: 3.0 is invalid"

<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**