### PR TITLE
Remove Synapse Pools from default setup

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "17681692497628322749"
+      "templateHash": "15582937476667412995"
     }
   },
   "parameters": {
@@ -6231,7 +6231,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "1803028102218246558"
+              "templateHash": "11458065933881293255"
             }
           },
           "parameters": {
@@ -6468,7 +6468,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "13095982571376811461"
+                      "templateHash": "8679177942379137286"
                     }
                   },
                   "parameters": {
@@ -6559,55 +6559,6 @@
                           "computeSubnetId": "[parameters('synapseComputeSubnetId')]"
                         }
                       }
-                    },
-                    {
-                      "type": "Microsoft.Synapse/workspaces/sqlPools",
-                      "apiVersion": "2021-03-01",
-                      "name": "[format('{0}/{1}', parameters('synapseName'), 'sqlPool001')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "sku": {
-                        "name": "DW100c"
-                      },
-                      "properties": {
-                        "collation": "SQL_Latin1_General_CP1_CI_AS",
-                        "createMode": "Default",
-                        "storageAccountType": "GRS"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Synapse/workspaces', parameters('synapseName'))]"
-                      ]
-                    },
-                    {
-                      "type": "Microsoft.Synapse/workspaces/bigDataPools",
-                      "apiVersion": "2021-03-01",
-                      "name": "[format('{0}/{1}', parameters('synapseName'), 'bigDataPool001')]",
-                      "location": "[parameters('location')]",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "autoPause": {
-                          "enabled": true,
-                          "delayInMinutes": 15
-                        },
-                        "autoScale": {
-                          "enabled": true,
-                          "maxNodeCount": 10,
-                          "minNodeCount": 3
-                        },
-                        "customLibraries": [],
-                        "defaultSparkLogFolder": "logs/",
-                        "dynamicExecutorAllocation": {
-                          "enabled": true
-                        },
-                        "nodeSize": "Small",
-                        "nodeSizeFamily": "MemoryOptimized",
-                        "sessionLevelPackagesEnabled": true,
-                        "sparkEventsFolder": "events/",
-                        "sparkVersion": "3.1"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Synapse/workspaces', parameters('synapseName'))]"
-                      ]
                     },
                     {
                       "type": "Microsoft.Synapse/workspaces/managedIdentitySqlControlSettings",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "15582937476667412995"
+      "templateHash": "14855675369895544620"
     }
   },
   "parameters": {
@@ -5139,7 +5139,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "13127185223595451873"
+              "templateHash": "12838599591005772497"
             }
           },
           "parameters": {
@@ -5249,7 +5249,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "3158553689611505689"
+                      "templateHash": "2447281483125098022"
                     }
                   },
                   "parameters": {
@@ -5276,7 +5276,7 @@
                   "resources": [
                     {
                       "type": "Microsoft.Databricks/workspaces",
-                      "apiVersion": "2018-04-01",
+                      "apiVersion": "2021-04-01-preview",
                       "name": "[parameters('databricksName')]",
                       "location": "[parameters('location')]",
                       "tags": "[parameters('tags')]",
@@ -6231,7 +6231,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "11458065933881293255"
+              "templateHash": "4716596571283833800"
             }
           },
           "parameters": {
@@ -6335,7 +6335,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "3158553689611505689"
+                      "templateHash": "2447281483125098022"
                     }
                   },
                   "parameters": {
@@ -6362,7 +6362,7 @@
                   "resources": [
                     {
                       "type": "Microsoft.Databricks/workspaces",
-                      "apiVersion": "2018-04-01",
+                      "apiVersion": "2021-04-01-preview",
                       "name": "[parameters('databricksName')]",
                       "location": "[parameters('location')]",
                       "tags": "[parameters('tags')]",

--- a/infra/modules/services/databricks.bicep
+++ b/infra/modules/services/databricks.bicep
@@ -15,7 +15,7 @@ param publicSubnetName string
 // Variables
 
 // Resources
-resource databricks 'Microsoft.Databricks/workspaces@2018-04-01' = {
+resource databricks 'Microsoft.Databricks/workspaces@2021-04-01-preview' = {
   name: databricksName
   location: location
   tags: tags

--- a/infra/modules/services/synapse.bicep
+++ b/infra/modules/services/synapse.bicep
@@ -59,58 +59,58 @@ resource synapse 'Microsoft.Synapse/workspaces@2021-03-01' = {
   }
 }
 
-resource synapseSqlPool001 'Microsoft.Synapse/workspaces/sqlPools@2021-03-01' = {
-  parent: synapse
-  name: 'sqlPool001'
-  location: location
-  tags: tags
-  sku: {
-    name: 'DW100c'
-  }
-  properties: {
-    collation: 'SQL_Latin1_General_CP1_CI_AS'
-    createMode: 'Default'
-    storageAccountType: 'GRS'
-  }
-}
+// resource synapseSqlPool001 'Microsoft.Synapse/workspaces/sqlPools@2021-03-01' = {  // Uncomment if you want to deploy a Synapse Spark Pool as part of your Data Landing Zone inside the shared product resource group
+//   parent: synapse
+//   name: 'sqlPool001'
+//   location: location
+//   tags: tags
+//   sku: {
+//     name: 'DW100c'
+//   }
+//   properties: {
+//     collation: 'SQL_Latin1_General_CP1_CI_AS'
+//     createMode: 'Default'
+//     storageAccountType: 'GRS'
+//   }
+// }
 
-resource synapseBigDataPool001 'Microsoft.Synapse/workspaces/bigDataPools@2021-03-01' = {
-  parent: synapse
-  name: 'bigDataPool001'
-  location: location
-  tags: tags
-  properties: {
-    autoPause: {
-      enabled: true
-      delayInMinutes: 15
-    }
-    autoScale: {
-      enabled: true
-      maxNodeCount: 10
-      minNodeCount: 3
-    }
-    // cacheSize: 100  // Uncomment to set a specific cache size
-    customLibraries: []
-    defaultSparkLogFolder: 'logs/'
-    dynamicExecutorAllocation: {
-      enabled: true
-    }
-    // isComputeIsolationEnabled: true  // Uncomment to enable compute isolation (only available in selective regions)
-    // libraryRequirements: {  // Uncomment to install pip dependencies on the Spark cluster
-    //   content: ''
-    //   filename: 'requirements.txt'
-    // }
-    nodeSize: 'Small'
-    nodeSizeFamily: 'MemoryOptimized'
-    sessionLevelPackagesEnabled: true
-    // sparkConfigProperties: {  // Uncomment to set spark conf on the Spark cluster
-    //   content: ''
-    //   filename: 'spark.conf'
-    // }
-    sparkEventsFolder: 'events/'
-    sparkVersion: '3.1'
-  }
-}
+// resource synapseBigDataPool001 'Microsoft.Synapse/workspaces/bigDataPools@2021-03-01' = {  // Uncomment if you want to deploy a Synapse SQL Pool as part of your Data Landing Zone inside the shared product resource group
+//   parent: synapse
+//   name: 'bigDataPool001'
+//   location: location
+//   tags: tags
+//   properties: {
+//     autoPause: {
+//       enabled: true
+//       delayInMinutes: 15
+//     }
+//     autoScale: {
+//       enabled: true
+//       maxNodeCount: 10
+//       minNodeCount: 3
+//     }
+//     // cacheSize: 100  // Uncomment to set a specific cache size
+//     customLibraries: []
+//     defaultSparkLogFolder: 'logs/'
+//     dynamicExecutorAllocation: {
+//       enabled: true
+//     }
+//     // isComputeIsolationEnabled: true  // Uncomment to enable compute isolation (only available in selective regions)
+//     // libraryRequirements: {  // Uncomment to install pip dependencies on the Spark cluster
+//     //   content: ''
+//     //   filename: 'requirements.txt'
+//     // }
+//     nodeSize: 'Small'
+//     nodeSizeFamily: 'MemoryOptimized'
+//     sessionLevelPackagesEnabled: true
+//     // sparkConfigProperties: {  // Uncomment to set spark conf on the Spark cluster
+//     //   content: ''
+//     //   filename: 'spark.conf'
+//     // }
+//     sparkEventsFolder: 'events/'
+//     sparkVersion: '3.1'
+//   }
+// }
 
 resource synapseManagedIdentitySqlControlSettings 'Microsoft.Synapse/workspaces/managedIdentitySqlControlSettings@2021-03-01' = {
   parent: synapse


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
* It removes the Synapse Spark pool and SQL pool from the deployment. This shared synapse instance is not something that is generally not used due to limitations on visibility of code artifacts and single git connection. Hence, these will most likely be deployed as part of the product deployments and can be removed from the core landing zone setup.