### PR TITLE
Add Resource Group Lock for Data Lakes

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "1749470466635824666"
+      "templateHash": "13166319048969332866"
     }
   },
   "parameters": {
@@ -2778,7 +2778,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "15390355243573116252"
+              "templateHash": "15601587954198620788"
             }
           },
           "parameters": {
@@ -3798,7 +3798,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "15970337114729251288"
+                      "templateHash": "13838143596572751245"
                     }
                   },
                   "parameters": {
@@ -3815,7 +3815,7 @@
                   "resources": [
                     {
                       "type": "Microsoft.Authorization/locks",
-                      "apiVersion": "2016-09-01",
+                      "apiVersion": "2021-01-01",
                       "name": "lock",
                       "properties": {
                         "level": "[parameters('lockEffect')]",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "4109190605093468141"
+      "templateHash": "1749470466635824666"
     }
   },
   "parameters": {
@@ -2778,7 +2778,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "15947388376654117579"
+              "templateHash": "15390355243573116252"
             }
           },
           "parameters": {
@@ -3774,6 +3774,55 @@
                       }
                     }
                   }
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2019-10-01",
+              "name": "lock",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "lockEffect": {
+                    "value": "CanNotDelete"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.613.9944",
+                      "templateHash": "15970337114729251288"
+                    }
+                  },
+                  "parameters": {
+                    "lockEffect": {
+                      "type": "string",
+                      "defaultValue": "CanNotDelete",
+                      "allowedValues": [
+                        "CanNotDelete",
+                        "ReadOnly"
+                      ]
+                    }
+                  },
+                  "functions": [],
+                  "resources": [
+                    {
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2016-09-01",
+                      "name": "lock",
+                      "properties": {
+                        "level": "[parameters('lockEffect')]",
+                        "notes": "Prevent Deletion of Resource Group and resources within the Resource Group."
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/infra/modules/services/lock.bicep
+++ b/infra/modules/services/lock.bicep
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// This template is used to create a lock.
+targetScope = 'resourceGroup'
+
+// Parameters
+@allowed([
+  'CanNotDelete'
+  'ReadOnly'
+])
+param lockEffect string = 'CanNotDelete'
+
+// Variables
+
+// Resources
+resource lock 'Microsoft.Authorization/locks@2016-09-01' = {
+  name: 'lock'
+  properties: {
+    level: lockEffect
+    notes: 'Prevent Deletion of Resource Group and resources within the Resource Group.'
+  }
+}
+
+// Outputs

--- a/infra/modules/services/lock.bicep
+++ b/infra/modules/services/lock.bicep
@@ -14,7 +14,7 @@ param lockEffect string = 'CanNotDelete'
 // Variables
 
 // Resources
-resource lock 'Microsoft.Authorization/locks@2016-09-01' = {
+resource lock 'Microsoft.Authorization/locks@2021-01-01' = {
   name: 'lock'
   properties: {
     level: lockEffect

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -71,6 +71,14 @@ module storageWorkspace 'services/storage.bicep' = {
   }
 }
 
+module lock 'services/lock.bicep' = {
+  name: 'lock'
+  scope: resourceGroup()
+  params: {
+    lockEffect: 'CanNotDelete'
+  }
+}
+
 // Outputs
 output storageRawId string = storageRaw.outputs.storageId
 output storageRawFileSystemId string = storageRaw.outputs.storageFileSystemIds[0].storageFileSystemId


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
* This PR adds Resource Group level Locks to prevent accidental deletion of Data Lakes ina  Data Landing Zone. This is only a mechanism to prevent accidental deletes. Users with appropriate access rights ("Microsoft.Authorization/*") can potentially also remove the lock. This will only be applied to the Storage RG, as for other services we have native DR features such as: Key Vault - Purge Protection and Soft Delete, SQL - GRS Backups, etc. For other services, teams should check in their code into a repository, in order to be able to re-create the setup, pipelines and application code.