### PR TITLE
Add Data Landing Zone Subs to Storage Firewall

### DIFF
--- a/.github/linters/.arm-ttk.psd1
+++ b/.github/linters/.arm-ttk.psd1
@@ -4,11 +4,13 @@
 @{
     # Test = @( )
     Skip = @(
-        'Template Should Not Contain Blanks',
-        'DeploymentTemplate Must Not Contain Hardcoded Uri',
-        'DependsOn Best Practices',
-        'Outputs Must Not Contain Secrets',
-        'IDs Should Be Derived From ResourceIDs',
+        'Template Should Not Contain Blanks'
+        'DeploymentTemplate Must Not Contain Hardcoded Uri'
+        'DependsOn Best Practices'
+        'Outputs Must Not Contain Secrets'
+        'IDs Should Be Derived From ResourceIDs'
         'apiVersions Should Be Recent'
+        'Parameters Must Be Referenced'
+        'Variables Must Be Referenced'
     )
 }

--- a/docs/DataManagementAnalytics-AzureDevOpsDeployment.md
+++ b/docs/DataManagementAnalytics-AzureDevOpsDeployment.md
@@ -92,6 +92,7 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | `purviewManagedEventHubId` | Specifies the Resource ID of the managed event hub of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.EventHub/namespaces/{eventhub-namespace-name}` |
 | `purviewSelfHostedIntegrationRuntimeAuthKey` | Specifies the Auth Key for the Self-hosted integration runtime of Purview. | `<your-purview-shir-auth-key>` |
 | `deploySelfHostedIntegrationRuntimes` | Specifies whether the self-hosted integration runtimes should be installed. This only works, if the pwsh script was uploded and is available. | `true` or `false` |
+| `dataLandingZoneSubscriptionIds` | Specifies the subscription IDs of the other Data Landing Zones. | `[ '{subscriptionId1}', '{subscriptionId2}' ]` |
 | `privateDnsZoneIdKeyVault` | Specifies the Resource ID of the private DNS zone for KeyVault. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net` |
 | `privateDnsZoneIdDataFactory` | Specifies the Resource ID of the private DNS zone for Data Factory. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.datafactory.azure.net` |
 | `privateDnsZoneIdDataFactoryPortal` | Specifies the Resource ID of the private DNS zone for Data Factory Portal. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.adf.azure.com` |

--- a/docs/DataManagementAnalytics-GitHubActionsDeployment.md
+++ b/docs/DataManagementAnalytics-GitHubActionsDeployment.md
@@ -84,6 +84,7 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | `purviewManagedEventHubId` | Specifies the Resource ID of the managed event hub of the central purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.EventHub/namespaces/{eventhub-namespace-name}` |
 | `purviewSelfHostedIntegrationRuntimeAuthKey` | Specifies the Auth Key for the Self-hosted integration runtime of Purview. | `<your-purview-shir-auth-key>` |
 | `deploySelfHostedIntegrationRuntimes` | Specifies whether the self-hosted integration runtimes should be deployed. This only works, if the pwsh script was uploded and is available. | `true` or `false` |
+| `dataLandingZoneSubscriptionIds` | Specifies the subscription IDs of the other Data Landing Zones. | `[ '{subscriptionId1}', '{subscriptionId2}' ]` |
 | `privateDnsZoneIdKeyVault` | Specifies the Resource ID of the private DNS zone for KeyVault. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net` |
 | `privateDnsZoneIdDataFactory` | Specifies the Resource ID of the private DNS zone for Data Factory. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.datafactory.azure.net` |
 | `privateDnsZoneIdDataFactoryPortal` | Specifies the Resource ID of the private DNS zone for Data Factory Portal. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.adf.azure.com` |

--- a/docs/reference/portal.dataLandingZone.json
+++ b/docs/reference/portal.dataLandingZone.json
@@ -514,6 +514,71 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "name": "dataLandingZoneSubscriptions",
+                            "label": "Other Data Landing Zone Subscriptions",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "elements": [
+                                {
+                                    "name": "selfhostedIntegrationRuntimeText",
+                                    "type": "Microsoft.Common.TextBlock",
+                                    "visible": true,
+                                    "options": {
+                                        "text": "Specify the subscriptions that are used for your other Data Landing Zones.",
+                                        "link": {
+                                            "label": "",
+                                            "uri": ""
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "subscriptionApi",
+                                    "type": "Microsoft.Solutions.ArmApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "subscriptions?api-version=2020-01-01"
+                                    }
+                                },
+                                {
+                                    "name": "dataLandingZoneSubscriptionIds",
+                                    "ariaLabel": "Enter information per Data Landing Zone",
+                                    "label": "Data Landing Zone Subscriptions",
+                                    "type": "Microsoft.Common.EditableGrid",
+                                    "visible": true,
+                                    "constraints": {
+                                        "width": "Full",
+                                        "rows": {
+                                            "count": {
+                                                "min": 0,
+                                                "max": 50
+                                            }
+                                        },
+                                        "columns": [
+                                            {
+                                                "id": "subscription",
+                                                "header": "Subscription",
+                                                "width": "1fr",
+                                                "element": {
+                                                    "name": "subscription",
+                                                    "type": "Microsoft.Common.DropDown",
+                                                    "placeholder": "Select a subscription...",
+                                                    "multiselect": false,
+                                                    "selectAll": false,
+                                                    "filter": true,
+                                                    "filterPlaceholder": "Filter items ...",
+                                                    "multiLine": true,
+                                                    "constraints": {
+                                                        "allowedValues": "[map(steps('generalSettings').dataLandingZoneSubscriptions.subscriptionApi.value, (item) => parse(concat('{\"label\":\"', item.displayName, '\",\"value\":\"', item.subscriptionId, '\",\"description\":\"', 'ID: ', item.subscriptionId, '\"}')))]",
+                                                        "required": true
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -1406,6 +1471,7 @@
                 "purviewId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewId.id)]",
                 "purviewManagedStorageId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewApi.properties.managedResources.storageAccount)]",
                 "purviewManagedEventHubId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewApi.properties.managedResources.eventHubNamespace)]",
+                "dataLandingZoneSubscriptionIds": "[if(empty(steps('generalSettings').dataLandingZoneSubscriptions.dataLandingZoneSubscriptionIds), parse('[]'), map(steps('generalSettings').dataLandingZoneSubscriptions.dataLandingZoneSubscriptionIds, (item) => item.subscription))]",
                 "privateDnsZoneIdKeyVault": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault)]",
                 "privateDnsZoneIdDataFactory": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdDataFactory), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdDataFactory)]",
                 "privateDnsZoneIdDataFactoryPortal": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdDataFactoryPortal), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdDataFactoryPortal)]",

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -67,6 +67,8 @@ param purviewManagedEventHubId string = ''
 param purviewSelfHostedIntegrationRuntimeAuthKey string = ''
 @description('Specifies whether the self-hosted integration runtimes should be deployed.')
 param deploySelfHostedIntegrationRuntimes bool = false
+@description('Specifies the subscription IDs of the other Data Landing Zones.')
+param dataLandingZoneSubscriptionIds array = []
 
 // Private DNS Zone parameters
 @description('Specifies the resource ID of the private DNS zone for Key Vault.')
@@ -210,6 +212,7 @@ module storageServices 'modules/storage.bicep' = {
     purviewId: purviewId
     privateDnsZoneIdBlob: privateDnsZoneIdBlob
     privateDnsZoneIdDfs: privateDnsZoneIdDfs
+    dataLandingZoneSubscriptionIds: dataLandingZoneSubscriptionIds
   }
 }
 
@@ -231,6 +234,7 @@ module externalStorageServices 'modules/externalstorage.bicep' = {
     purviewId: purviewId
     subnetId: networkServices.outputs.servicesSubnetId
     privateDnsZoneIdBlob: privateDnsZoneIdBlob
+    dataLandingZoneSubscriptionIds: dataLandingZoneSubscriptionIds
   }
 }
 
@@ -386,6 +390,7 @@ output mySqlServer001ResourceGroupName string = split(metadataServices.outputs.m
 output mySqlServer001Name string = last(split(metadataServices.outputs.mySqlServer001Id, '/'))
 output mySqlServer001KeyVaultid string = metadataServices.outputs.keyVault001Id
 output mySqlServer001UsernameSecretName string = metadataServices.outputs.mySqlServer001UsernameSecretName
+#disable-next-line outputs-should-not-contain-secrets
 output mySqlServer001PasswordSecretName string = metadataServices.outputs.mySqlServer001PasswordSecretName
 output mySqlServer001ConnectionStringSecretName string = metadataServices.outputs.mySqlServer001ConnectionStringSecretName
 output logAnalyticsWorkspaceKeyVaultId string = loggingServices.outputs.logAnalytics001WorkspaceKeyVaultId

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1008.15138",
-      "templateHash": "3869477483557194275"
+      "version": "0.4.1124.51302",
+      "templateHash": "7618844142089139852"
     }
   },
   "parameters": {
@@ -183,6 +183,13 @@
         "description": "Specifies whether the self-hosted integration runtimes should be deployed."
       }
     },
+    "dataLandingZoneSubscriptionIds": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Specifies the subscription IDs of the other Data Landing Zones."
+      }
+    },
     "privateDnsZoneIdKeyVault": {
       "type": "string",
       "defaultValue": "",
@@ -254,7 +261,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "name": "[toLower(format('{0}-{1}', parameters('prefix'), parameters('environment')))]",
     "tagsDefault": {
@@ -374,7 +380,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "networkServices",
       "resourceGroup": "[format('{0}-network', variables('name'))]",
       "properties": {
@@ -441,8 +447,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "7279192272160550381"
+              "version": "0.4.1124.51302",
+              "templateHash": "13883560175464909401"
             }
           },
           "parameters": {
@@ -514,7 +520,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "variables": {
             "servicesSubnetName": "ServicesSubnet",
             "databricksIntegrationPrivateSubnetName": "DatabricksIntegrationSubnetPrivate",
@@ -989,7 +994,7 @@
             {
               "condition": "[not(empty(parameters('dataManagementZoneVnetId')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "[format('dataManagementZoneDataLandingZoneVnetPeering-{0}', parameters('prefix'))]",
               "subscriptionId": "[variables('dataManagementZoneVnetSubscriptionId')]",
               "resourceGroup": "[variables('dataManagementZoneVnetResourceGroupName')]",
@@ -1012,8 +1017,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4940841448708002583"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "7590205162005102223"
                     }
                   },
                   "parameters": {
@@ -1024,7 +1029,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "dataManagementZoneVnetName": "[if(greaterOrEquals(length(split(parameters('dataManagementZoneVnetId'), '/')), 9), last(split(parameters('dataManagementZoneVnetId'), '/')), 'incorrectSegmentLength')]",
                     "dataLandingZoneVnetName": "[if(greaterOrEquals(length(split(parameters('dataLandingZoneVnetId'), '/')), 9), last(split(parameters('dataLandingZoneVnetId'), '/')), 'incorrectSegmentLength')]"
@@ -1095,7 +1099,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "loggingServices",
       "resourceGroup": "[format('{0}-logging', variables('name'))]",
       "properties": {
@@ -1114,7 +1118,7 @@
             "value": "[variables('tagsJoined')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.servicesSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.servicesSubnetId.value]"
           },
           "privateDnsZoneIdKeyVault": {
             "value": "[parameters('privateDnsZoneIdKeyVault')]"
@@ -1126,8 +1130,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "11329328610317740718"
+              "version": "0.4.1124.51302",
+              "templateHash": "18313384142239512916"
             }
           },
           "parameters": {
@@ -1148,7 +1152,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "variables": {
             "keyVault001Name": "[format('{0}-vault003', parameters('prefix'))]",
             "logAnalytics001Name": "[format('{0}-la001', parameters('prefix'))]"
@@ -1156,7 +1159,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "keyVault001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1186,8 +1189,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "3071154434175438906"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "7953887992371664532"
                     }
                   },
                   "parameters": {
@@ -1208,7 +1211,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "keyVaultPrivateEndpointName": "[format('{0}-private-endpoint', parameters('keyvaultName'))]"
                   },
@@ -1305,7 +1307,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "logAnalytics001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1329,8 +1331,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17390569902175991778"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "7174668170069375842"
                     }
                   },
                   "parameters": {
@@ -1344,7 +1346,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.OperationalInsights/workspaces",
@@ -1374,7 +1375,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "logAnalytics001SecretDeployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1383,10 +1384,10 @@
                 "mode": "Incremental",
                 "parameters": {
                   "keyVaultId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyVault001'), '2020-06-01').outputs.keyvaultId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyVault001'), '2020-10-01').outputs.keyvaultId.value]"
                   },
                   "logAnalyticsId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalytics001'), '2020-06-01').outputs.logAnalyticsWorkspaceId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalytics001'), '2020-10-01').outputs.logAnalyticsWorkspaceId.value]"
                   }
                 },
                 "template": {
@@ -1395,8 +1396,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "10633963054739433768"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "4278436693389213326"
                     }
                   },
                   "parameters": {
@@ -1407,7 +1408,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "keyVaultName": "[if(greaterOrEquals(length(split(parameters('keyVaultId'), '/')), 9), last(split(parameters('keyVaultId'), '/')), 'incorrectSegmentLength')]",
                     "logAnalyticsSubscriptionId": "[if(greaterOrEquals(length(split(parameters('logAnalyticsId'), '/')), 9), split(parameters('logAnalyticsId'), '/')[2], subscription().subscriptionId)]",
@@ -1463,15 +1463,15 @@
           "outputs": {
             "logAnalytics001WorkspaceKeyVaultId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyVault001'), '2020-06-01').outputs.keyvaultId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyVault001'), '2020-10-01').outputs.keyvaultId.value]"
             },
             "logAnalytics001WorkspaceIdSecretName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalytics001SecretDeployment'), '2020-06-01').outputs.logAnalyticsWorkspaceIdSecretName.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalytics001SecretDeployment'), '2020-10-01').outputs.logAnalyticsWorkspaceIdSecretName.value]"
             },
             "logAnalytics001WorkspaceKeySecretName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalytics001SecretDeployment'), '2020-06-01').outputs.logAnalyticsWorkspaceKeySecretName.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalytics001SecretDeployment'), '2020-10-01').outputs.logAnalyticsWorkspaceKeySecretName.value]"
             }
           }
         }
@@ -1483,7 +1483,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "runtimeServices",
       "resourceGroup": "[format('{0}-runtimes', variables('name'))]",
       "properties": {
@@ -1502,7 +1502,7 @@
             "value": "[variables('tagsJoined')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.servicesSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.servicesSubnetId.value]"
           },
           "administratorUsername": {
             "value": "[variables('administratorUsername')]"
@@ -1527,7 +1527,7 @@
           },
           "datafactoryIds": {
             "value": [
-              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-06-01').outputs.datafactoryIntegration001Id.value]"
+              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-10-01').outputs.datafactoryIntegration001Id.value]"
             ]
           }
         },
@@ -1537,8 +1537,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "3091899515443697712"
+              "version": "0.4.1124.51302",
+              "templateHash": "1603392609139097624"
             }
           },
           "parameters": {
@@ -1585,7 +1585,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "variables": {
             "datafactoryRuntimes001Name": "[format('{0}-runtime-datafactory001', parameters('prefix'))]",
             "shir001Name": "[format('{0}-shir001', parameters('prefix'))]",
@@ -1606,7 +1605,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "datafactoryRuntimes001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1642,8 +1641,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "12317377009035085155"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "2848982979055113071"
                     }
                   },
                   "parameters": {
@@ -1672,7 +1671,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "datafactoryDefaultManagedVnetIntegrationRuntimeName": "AutoResolveIntegrationRuntime",
                     "datafactoryPrivateEndpointNameDatafactory": "[format('{0}-datafactory-private-endpoint', parameters('datafactoryName'))]",
@@ -1833,7 +1831,7 @@
             {
               "condition": "[parameters('deploySelfHostedIntegrationRuntimes')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "datafactoryRuntimes001SelfHostedIntegrationRuntime001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1878,8 +1876,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17374805133401694702"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "4035624844278024115"
                     }
                   },
                   "parameters": {
@@ -1918,7 +1916,6 @@
                       "type": "secureString"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "loadbalancerName": "[format('{0}-lb', parameters('vmssName'))]"
                   },
@@ -2120,7 +2117,7 @@
                 "count": "[length(parameters('datafactoryIds'))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "[format('shareDatafactoryRuntimes001IntegrationRuntime001-{0}', copyIndex())]",
               "subscriptionId": "[split(parameters('datafactoryIds')[copyIndex()], '/')[2]]",
               "resourceGroup": "[split(parameters('datafactoryIds')[copyIndex()], '/')[4]]",
@@ -2131,7 +2128,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "datafactorySourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryRuntimes001'), '2020-06-01').outputs.datafactoryId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryRuntimes001'), '2020-10-01').outputs.datafactoryId.value]"
                   },
                   "datafactorySourceShirId": {
                     "value": "[resourceId('Microsoft.DataFactory/factories/integrationRuntimes', split(format('{0}/dataLandingZoneShir-{1}', variables('datafactoryRuntimes001Name'), variables('shir001Name')), '/')[0], split(format('{0}/dataLandingZoneShir-{1}', variables('datafactoryRuntimes001Name'), variables('shir001Name')), '/')[1])]"
@@ -2146,8 +2143,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "5189850223937127106"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "10128936967068858782"
                     }
                   },
                   "parameters": {
@@ -2161,7 +2158,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "datafactorySourceSubscriptionId": "[if(greaterOrEquals(length(split(parameters('datafactorySourceId'), '/')), 9), split(parameters('datafactorySourceId'), '/')[2], subscription().subscriptionId)]",
                     "datafactorySourceResourceGroup": "[if(greaterOrEquals(length(split(parameters('datafactorySourceId'), '/')), 9), split(parameters('datafactorySourceId'), '/')[4], resourceGroup().name)]",
@@ -2190,7 +2186,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-06-01",
+                      "apiVersion": "2020-10-01",
                       "name": "datafactoryDestinationRoleAssignment",
                       "subscriptionId": "[variables('datafactorySourceSubscriptionId')]",
                       "resourceGroup": "[variables('datafactorySourceResourceGroup')]",
@@ -2213,8 +2209,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.4.1008.15138",
-                              "templateHash": "7836138008790151317"
+                              "version": "0.4.1124.51302",
+                              "templateHash": "15766075695400514976"
                             }
                           },
                           "parameters": {
@@ -2225,7 +2221,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "variables": {
                             "datafactorySourceName": "[if(greaterOrEquals(length(split(parameters('datafactorySourceId'), '/')), 9), last(split(parameters('datafactorySourceId'), '/')), 'incorrectSegmentLength')]",
                             "datafactoryDestinationSubscriptionId": "[if(greaterOrEquals(length(split(parameters('datafactoryDestinationId'), '/')), 9), split(parameters('datafactoryDestinationId'), '/')[2], subscription().subscriptionId)]",
@@ -2256,7 +2251,7 @@
                         "batchSize": 1
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-06-01",
+                      "apiVersion": "2020-10-01",
                       "name": "[format('delay-{0}', range(0, 10)[copyIndex()])]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -2274,8 +2269,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.4.1008.15138",
-                              "templateHash": "13546439864548302355"
+                              "version": "0.4.1124.51302",
+                              "templateHash": "701382971037194322"
                             }
                           },
                           "parameters": {
@@ -2283,7 +2278,6 @@
                               "type": "int"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "deploymentDelayIndex": {
@@ -2309,7 +2303,7 @@
             {
               "condition": "[and(parameters('deploySelfHostedIntegrationRuntimes'), not(equals(parameters('purviewSelfHostedIntegrationRuntimeAuthKey'), '')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "purviewSelfHostedIntegrationRuntime001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2354,8 +2348,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17374805133401694702"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "4035624844278024115"
                     }
                   },
                   "parameters": {
@@ -2394,7 +2388,6 @@
                       "type": "secureString"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "loadbalancerName": "[format('{0}-lb', parameters('vmssName'))]"
                   },
@@ -2597,7 +2590,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "storageServices",
       "resourceGroup": "[format('{0}-storage', variables('name'))]",
       "properties": {
@@ -2616,7 +2609,7 @@
             "value": "[variables('tagsJoined')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.servicesSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.servicesSubnetId.value]"
           },
           "purviewId": {
             "value": "[parameters('purviewId')]"
@@ -2626,6 +2619,9 @@
           },
           "privateDnsZoneIdDfs": {
             "value": "[parameters('privateDnsZoneIdDfs')]"
+          },
+          "dataLandingZoneSubscriptionIds": {
+            "value": "[parameters('dataLandingZoneSubscriptionIds')]"
           }
         },
         "template": {
@@ -2634,8 +2630,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "2241249390270477566"
+              "version": "0.4.1124.51302",
+              "templateHash": "2199353610392000178"
             }
           },
           "parameters": {
@@ -2662,9 +2658,12 @@
             "privateDnsZoneIdBlob": {
               "type": "string",
               "defaultValue": ""
+            },
+            "dataLandingZoneSubscriptionIds": {
+              "type": "array",
+              "defaultValue": []
             }
           },
-          "functions": [],
           "variables": {
             "storageRawName": "[format('{0}-raw', parameters('prefix'))]",
             "storageEnrichedCuratedName": "[format('{0}-encur', parameters('prefix'))]",
@@ -2683,7 +2682,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "storageRaw",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2714,6 +2713,9 @@
                   },
                   "purviewId": {
                     "value": "[parameters('purviewId')]"
+                  },
+                  "dataLandingZoneSubscriptionIds": {
+                    "value": "[parameters('dataLandingZoneSubscriptionIds')]"
                   }
                 },
                 "template": {
@@ -2722,8 +2724,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4350977779944189850"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "13029846851650780358"
                     }
                   },
                   "parameters": {
@@ -2753,14 +2755,31 @@
                     "purviewId": {
                       "type": "string",
                       "defaultValue": ""
+                    },
+                    "dataLandingZoneSubscriptionIds": {
+                      "type": "array",
+                      "defaultValue": []
                     }
                   },
-                  "functions": [],
                   "variables": {
+                    "copy": [
+                      {
+                        "name": "synapseResourceAccessrules",
+                        "count": "[length(union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId)))]",
+                        "input": {
+                          "tenantId": "[subscription().tenantId]",
+                          "resourceId": "[format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId))[copyIndex('synapseResourceAccessrules')])]"
+                        }
+                      }
+                    ],
                     "storageNameCleaned": "[replace(parameters('storageName'), '-', '')]",
                     "storagePrivateEndpointNameBlob": "[format('{0}-blob-private-endpoint', variables('storageNameCleaned'))]",
                     "storagePrivateEndpointNameDfs": "[format('{0}-dfs-private-endpoint', variables('storageNameCleaned'))]",
-                    "resourceAccessRules": "[if(empty(parameters('purviewId')), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId))), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId)), createObject('tenantId', subscription().tenantId, 'resourceId', parameters('purviewId'))))]"
+                    "purviewResourceAccessRules": {
+                      "tenantId": "[subscription().tenantId]",
+                      "resourceId": "[parameters('purviewId')]"
+                    },
+                    "resourceAccessRules": "[if(empty(parameters('purviewId')), variables('synapseResourceAccessrules'), union(variables('synapseResourceAccessrules'), array(variables('purviewResourceAccessRules'))))]"
                   },
                   "resources": [
                     {
@@ -3009,7 +3028,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "storageEnrichedCurated",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3040,6 +3059,9 @@
                   },
                   "purviewId": {
                     "value": "[parameters('purviewId')]"
+                  },
+                  "dataLandingZoneSubscriptionIds": {
+                    "value": "[parameters('dataLandingZoneSubscriptionIds')]"
                   }
                 },
                 "template": {
@@ -3048,8 +3070,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4350977779944189850"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "13029846851650780358"
                     }
                   },
                   "parameters": {
@@ -3079,14 +3101,31 @@
                     "purviewId": {
                       "type": "string",
                       "defaultValue": ""
+                    },
+                    "dataLandingZoneSubscriptionIds": {
+                      "type": "array",
+                      "defaultValue": []
                     }
                   },
-                  "functions": [],
                   "variables": {
+                    "copy": [
+                      {
+                        "name": "synapseResourceAccessrules",
+                        "count": "[length(union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId)))]",
+                        "input": {
+                          "tenantId": "[subscription().tenantId]",
+                          "resourceId": "[format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId))[copyIndex('synapseResourceAccessrules')])]"
+                        }
+                      }
+                    ],
                     "storageNameCleaned": "[replace(parameters('storageName'), '-', '')]",
                     "storagePrivateEndpointNameBlob": "[format('{0}-blob-private-endpoint', variables('storageNameCleaned'))]",
                     "storagePrivateEndpointNameDfs": "[format('{0}-dfs-private-endpoint', variables('storageNameCleaned'))]",
-                    "resourceAccessRules": "[if(empty(parameters('purviewId')), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId))), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId)), createObject('tenantId', subscription().tenantId, 'resourceId', parameters('purviewId'))))]"
+                    "purviewResourceAccessRules": {
+                      "tenantId": "[subscription().tenantId]",
+                      "resourceId": "[parameters('purviewId')]"
+                    },
+                    "resourceAccessRules": "[if(empty(parameters('purviewId')), variables('synapseResourceAccessrules'), union(variables('synapseResourceAccessrules'), array(variables('purviewResourceAccessRules'))))]"
                   },
                   "resources": [
                     {
@@ -3335,7 +3374,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "storageWorkspace",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3366,6 +3405,9 @@
                   },
                   "purviewId": {
                     "value": "[parameters('purviewId')]"
+                  },
+                  "dataLandingZoneSubscriptionIds": {
+                    "value": "[parameters('dataLandingZoneSubscriptionIds')]"
                   }
                 },
                 "template": {
@@ -3374,8 +3416,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4350977779944189850"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "13029846851650780358"
                     }
                   },
                   "parameters": {
@@ -3405,14 +3447,31 @@
                     "purviewId": {
                       "type": "string",
                       "defaultValue": ""
+                    },
+                    "dataLandingZoneSubscriptionIds": {
+                      "type": "array",
+                      "defaultValue": []
                     }
                   },
-                  "functions": [],
                   "variables": {
+                    "copy": [
+                      {
+                        "name": "synapseResourceAccessrules",
+                        "count": "[length(union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId)))]",
+                        "input": {
+                          "tenantId": "[subscription().tenantId]",
+                          "resourceId": "[format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId))[copyIndex('synapseResourceAccessrules')])]"
+                        }
+                      }
+                    ],
                     "storageNameCleaned": "[replace(parameters('storageName'), '-', '')]",
                     "storagePrivateEndpointNameBlob": "[format('{0}-blob-private-endpoint', variables('storageNameCleaned'))]",
                     "storagePrivateEndpointNameDfs": "[format('{0}-dfs-private-endpoint', variables('storageNameCleaned'))]",
-                    "resourceAccessRules": "[if(empty(parameters('purviewId')), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId))), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId)), createObject('tenantId', subscription().tenantId, 'resourceId', parameters('purviewId'))))]"
+                    "purviewResourceAccessRules": {
+                      "tenantId": "[subscription().tenantId]",
+                      "resourceId": "[parameters('purviewId')]"
+                    },
+                    "resourceAccessRules": "[if(empty(parameters('purviewId')), variables('synapseResourceAccessrules'), union(variables('synapseResourceAccessrules'), array(variables('purviewResourceAccessRules'))))]"
                   },
                   "resources": [
                     {
@@ -3663,27 +3722,27 @@
           "outputs": {
             "storageRawId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageRaw'), '2020-06-01').outputs.storageId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageRaw'), '2020-10-01').outputs.storageId.value]"
             },
             "storageRawFileSystemId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageRaw'), '2020-06-01').outputs.storageFileSystemIds.value[0].storageFileSystemId]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageRaw'), '2020-10-01').outputs.storageFileSystemIds.value[0].storageFileSystemId]"
             },
             "storageEnrichedCuratedId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageEnrichedCurated'), '2020-06-01').outputs.storageId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageEnrichedCurated'), '2020-10-01').outputs.storageId.value]"
             },
             "storageEnrichedCuratedFileSystemId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageEnrichedCurated'), '2020-06-01').outputs.storageFileSystemIds.value[0].storageFileSystemId]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageEnrichedCurated'), '2020-10-01').outputs.storageFileSystemIds.value[0].storageFileSystemId]"
             },
             "storageWorkspaceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageWorkspace'), '2020-06-01').outputs.storageId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageWorkspace'), '2020-10-01').outputs.storageId.value]"
             },
             "storageWorkspaceFileSystemId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageWorkspace'), '2020-06-01').outputs.storageFileSystemIds.value[0].storageFileSystemId]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storageWorkspace'), '2020-10-01').outputs.storageFileSystemIds.value[0].storageFileSystemId]"
             }
           }
         }
@@ -3695,7 +3754,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "externalStorageServices",
       "resourceGroup": "[format('{0}-externalstorage', variables('name'))]",
       "properties": {
@@ -3717,10 +3776,13 @@
             "value": "[parameters('purviewId')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.servicesSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.servicesSubnetId.value]"
           },
           "privateDnsZoneIdBlob": {
             "value": "[parameters('privateDnsZoneIdBlob')]"
+          },
+          "dataLandingZoneSubscriptionIds": {
+            "value": "[parameters('dataLandingZoneSubscriptionIds')]"
           }
         },
         "template": {
@@ -3729,8 +3791,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "13631667228081798033"
+              "version": "0.4.1124.51302",
+              "templateHash": "15595935015946830721"
             }
           },
           "parameters": {
@@ -3753,9 +3815,12 @@
             "privateDnsZoneIdBlob": {
               "type": "string",
               "defaultValue": ""
+            },
+            "dataLandingZoneSubscriptionIds": {
+              "type": "array",
+              "defaultValue": []
             }
           },
-          "functions": [],
           "variables": {
             "storageExternal001Name": "[format('{0}-ext001', parameters('prefix'))]",
             "fileSytemNames": [
@@ -3765,7 +3830,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "storageExternal001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3793,6 +3858,9 @@
                   },
                   "purviewId": {
                     "value": "[parameters('purviewId')]"
+                  },
+                  "dataLandingZoneSubscriptionIds": {
+                    "value": "[parameters('dataLandingZoneSubscriptionIds')]"
                   }
                 },
                 "template": {
@@ -3801,8 +3869,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4669412684747056012"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "17102192983244728525"
                     }
                   },
                   "parameters": {
@@ -3831,13 +3899,30 @@
                     "purviewId": {
                       "type": "string",
                       "defaultValue": ""
+                    },
+                    "dataLandingZoneSubscriptionIds": {
+                      "type": "array",
+                      "defaultValue": []
                     }
                   },
-                  "functions": [],
                   "variables": {
+                    "copy": [
+                      {
+                        "name": "synapseResourceAccessrules",
+                        "count": "[length(union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId)))]",
+                        "input": {
+                          "tenantId": "[subscription().tenantId]",
+                          "resourceId": "[format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', union(parameters('dataLandingZoneSubscriptionIds'), array(subscription().subscriptionId))[copyIndex('synapseResourceAccessrules')])]"
+                        }
+                      }
+                    ],
                     "storageNameCleaned": "[replace(parameters('storageName'), '-', '')]",
                     "storageExternalPrivateEndpointNameBlob": "[format('{0}-blob-private-endpoint', variables('storageNameCleaned'))]",
-                    "resourceAccessRules": "[if(empty(parameters('purviewId')), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId))), createArray(createObject('tenantId', subscription().tenantId, 'resourceId', format('/subscriptions/{0}/resourceGroups/*/providers/Microsoft.Synapse/workspaces/*', subscription().subscriptionId)), createObject('tenantId', subscription().tenantId, 'resourceId', parameters('purviewId'))))]"
+                    "purviewResourceAccessRules": {
+                      "tenantId": "[subscription().tenantId]",
+                      "resourceId": "[parameters('purviewId')]"
+                    },
+                    "resourceAccessRules": "[if(empty(parameters('purviewId')), variables('synapseResourceAccessrules'), union(variables('synapseResourceAccessrules'), array(variables('purviewResourceAccessRules'))))]"
                   },
                   "resources": [
                     {
@@ -4032,7 +4117,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "metadataServices",
       "resourceGroup": "[format('{0}-metadata', variables('name'))]",
       "properties": {
@@ -4051,7 +4136,7 @@
             "value": "[variables('tagsJoined')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.servicesSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.servicesSubnetId.value]"
           },
           "administratorUsername": {
             "value": "[variables('administratorUsername')]"
@@ -4087,8 +4172,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "2884512612568356633"
+              "version": "0.4.1124.51302",
+              "templateHash": "7539544899333460771"
             }
           },
           "parameters": {
@@ -4140,7 +4225,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "variables": {
             "keyVault001Name": "[format('{0}-vault001', parameters('prefix'))]",
             "keyVault002Name": "[format('{0}-vault002', parameters('prefix'))]",
@@ -4190,7 +4274,7 @@
                   "enabled": true
                 },
                 "contentType": "text/plain",
-                "value": "[format('jdbc:mysql://{0}.mysql.database.azure.com:3306/{1}?useSSL=true&requireSSL=false&enabledSslProtocolSuites=TLSv1.2', variables('mySqlServer001Name'), reference(resourceId('Microsoft.Resources/deployments', 'mysqlserver001'), '2020-06-01').outputs.mySqlServerDatabaseName.value)]"
+                "value": "[format('jdbc:mysql://{0}.mysql.database.azure.com:3306/{1}?useSSL=true&requireSSL=false&enabledSslProtocolSuites=TLSv1.2', variables('mySqlServer001Name'), reference(resourceId('Microsoft.Resources/deployments', 'mysqlserver001'), '2020-10-01').outputs.mySqlServerDatabaseName.value)]"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', 'keyVault002')]",
@@ -4199,7 +4283,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "keyVault001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4229,8 +4313,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "3071154434175438906"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "7953887992371664532"
                     }
                   },
                   "parameters": {
@@ -4251,7 +4335,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "keyVaultPrivateEndpointName": "[format('{0}-private-endpoint', parameters('keyvaultName'))]"
                   },
@@ -4348,7 +4431,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "keyVault002",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4378,8 +4461,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "3071154434175438906"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "7953887992371664532"
                     }
                   },
                   "parameters": {
@@ -4400,7 +4483,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "keyVaultPrivateEndpointName": "[format('{0}-private-endpoint', parameters('keyvaultName'))]"
                   },
@@ -4497,7 +4579,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "sqlserver001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4539,8 +4621,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "9134634449113976144"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "15306404181792341643"
                     }
                   },
                   "parameters": {
@@ -4576,7 +4658,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "sqlserverAdfMetastoreDbName": "AdfMetastoreDb",
                     "sqlserverPrivateEndpointName": "[format('{0}-private-endpoint', parameters('sqlserverName'))]"
@@ -4706,7 +4787,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "mysqlserver001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -4748,8 +4829,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "17330916102436121321"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "8708549651324582183"
                     }
                   },
                   "parameters": {
@@ -4785,7 +4866,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "mySqlServerDatabaseName": "HiveMetastoreDb",
                     "mysqlserverPrivateEndpointName": "[format('{0}-private-endpoint', parameters('mysqlserverName'))]"
@@ -4928,19 +5008,19 @@
           "outputs": {
             "keyVault001Id": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyVault001'), '2020-06-01').outputs.keyvaultId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyVault001'), '2020-10-01').outputs.keyvaultId.value]"
             },
             "sqlServer001Id": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sqlserver001'), '2020-06-01').outputs.sqlServerId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sqlserver001'), '2020-10-01').outputs.sqlServerId.value]"
             },
             "sqlServer001DatabaseName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sqlserver001'), '2020-06-01').outputs.sqlServerDatabaseName.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sqlserver001'), '2020-10-01').outputs.sqlServerDatabaseName.value]"
             },
             "mySqlServer001Id": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'mysqlserver001'), '2020-06-01').outputs.mySqlServerId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'mysqlserver001'), '2020-10-01').outputs.mySqlServerId.value]"
             },
             "mySqlServer001UsernameSecretName": {
               "type": "string",
@@ -4964,7 +5044,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "sharedIntegrationServices",
       "resourceGroup": "[format('{0}-shared-integration', variables('name'))]",
       "properties": {
@@ -4983,37 +5063,37 @@
             "value": "[variables('tagsJoined')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.servicesSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.servicesSubnetId.value]"
           },
           "vnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.vnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.vnetId.value]"
           },
           "databricksIntegration001PrivateSubnetName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.databricksIntegrationPrivateSubnetName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.databricksIntegrationPrivateSubnetName.value]"
           },
           "databricksIntegration001PublicSubnetName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.databricksIntegrationPublicSubnetName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.databricksIntegrationPublicSubnetName.value]"
           },
           "storageRawId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-06-01').outputs.storageRawId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-10-01').outputs.storageRawId.value]"
           },
           "storageAccountRawFileSystemId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-06-01').outputs.storageRawFileSystemId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-10-01').outputs.storageRawFileSystemId.value]"
           },
           "storageEnrichedCuratedId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-06-01').outputs.storageEnrichedCuratedId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-10-01').outputs.storageEnrichedCuratedId.value]"
           },
           "storageAccountEnrichedCuratedFileSystemId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-06-01').outputs.storageEnrichedCuratedFileSystemId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-10-01').outputs.storageEnrichedCuratedFileSystemId.value]"
           },
           "keyVault001Id": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.keyVault001Id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.keyVault001Id.value]"
           },
           "sqlServer001Id": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.sqlServer001Id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.sqlServer001Id.value]"
           },
           "sqlDatabase001Name": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.sqlServer001DatabaseName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.sqlServer001DatabaseName.value]"
           },
           "purviewId": {
             "value": "[parameters('purviewId')]"
@@ -5040,8 +5120,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "17430668175094074912"
+              "version": "0.4.1124.51302",
+              "templateHash": "13126828723977985357"
             }
           },
           "parameters": {
@@ -5112,7 +5192,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "variables": {
             "databricksIntegration001Name": "[format('{0}-integration-databricks001', parameters('prefix'))]",
             "eventhubNamespaceIntegration001Name": "[format('{0}-integration-eventhub001', parameters('prefix'))]",
@@ -5125,7 +5204,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "databricksIntegration001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -5158,8 +5237,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "7120584334142234558"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "4105412995154385767"
                     }
                   },
                   "parameters": {
@@ -5182,7 +5261,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Databricks/workspaces",
@@ -5237,7 +5315,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "eventhubNamespaceIntegration001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -5273,8 +5351,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "4921491062221041793"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "2928587827510322525"
                     }
                   },
                   "parameters": {
@@ -5307,7 +5385,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "eventhubNamespacePrivateEndpointName": "[format('{0}-private-endpoint', parameters('eventhubnamespaceName'))]"
                   },
@@ -5401,7 +5478,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "datafactoryIntegration001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -5443,10 +5520,10 @@
                     "value": "[parameters('storageEnrichedCuratedId')]"
                   },
                   "databricks001Id": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-06-01').outputs.databricksId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-10-01').outputs.databricksId.value]"
                   },
                   "databricks001WorkspaceUrl": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-06-01').outputs.databricksWorkspaceUrl.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-10-01').outputs.databricksWorkspaceUrl.value]"
                   },
                   "keyVault001Id": {
                     "value": "[parameters('keyVault001Id')]"
@@ -5464,8 +5541,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "8237231481506109378"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "1482991792595615470"
                     }
                   },
                   "parameters": {
@@ -5523,7 +5600,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "storageRawName": "[if(greaterOrEquals(length(split(parameters('storageRawId'), '/')), 9), last(split(parameters('storageRawId'), '/')), 'incorrectSegmentLength')]",
                     "storageEnrichedCuratedName": "[if(greaterOrEquals(length(split(parameters('storageEnrichedCuratedId'), '/')), 9), last(split(parameters('storageEnrichedCuratedId'), '/')), 'incorrectSegmentLength')]",
@@ -5951,7 +6027,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "datafactory001StorageRawRoleAssignment",
               "subscriptionId": "[variables('storageAccountRawSubscriptionId')]",
               "resourceGroup": "[variables('storageAccountRawResourceGroupName')]",
@@ -5962,7 +6038,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "datafactoryId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-06-01').outputs.datafactoryId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-10-01').outputs.datafactoryId.value]"
                   },
                   "storageAccountFileSystemId": {
                     "value": "[parameters('storageAccountRawFileSystemId')]"
@@ -5974,8 +6050,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "2944316634128590685"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "14989401111182244541"
                     }
                   },
                   "parameters": {
@@ -5986,7 +6062,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "storageAccountFileSystemName": "[if(greaterOrEquals(length(split(parameters('storageAccountFileSystemId'), '/')), 13), last(split(parameters('storageAccountFileSystemId'), '/')), 'incorrectSegmentLength')]",
                     "storageAccountName": "[if(greaterOrEquals(length(split(parameters('storageAccountFileSystemId'), '/')), 13), split(parameters('storageAccountFileSystemId'), '/')[8], 'incorrectSegmentLength')]",
@@ -6015,7 +6090,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "datafactory001StorageEnrichedCuratedRoleAssignment",
               "subscriptionId": "[variables('storageAccountEnrichedCuratedSubscriptionId')]",
               "resourceGroup": "[variables('storageAccountEnrichedCuratedResourceGroupName')]",
@@ -6026,7 +6101,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "datafactoryId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-06-01').outputs.datafactoryId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-10-01').outputs.datafactoryId.value]"
                   },
                   "storageAccountFileSystemId": {
                     "value": "[parameters('storageAccountEnrichedCuratedFileSystemId')]"
@@ -6038,8 +6113,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "2944316634128590685"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "14989401111182244541"
                     }
                   },
                   "parameters": {
@@ -6050,7 +6125,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "storageAccountFileSystemName": "[if(greaterOrEquals(length(split(parameters('storageAccountFileSystemId'), '/')), 13), last(split(parameters('storageAccountFileSystemId'), '/')), 'incorrectSegmentLength')]",
                     "storageAccountName": "[if(greaterOrEquals(length(split(parameters('storageAccountFileSystemId'), '/')), 13), split(parameters('storageAccountFileSystemId'), '/')[8], 'incorrectSegmentLength')]",
@@ -6079,7 +6153,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "datafactory001DatabricksRoleAssignment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -6088,10 +6162,10 @@
                 "mode": "Incremental",
                 "parameters": {
                   "datafactoryId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-06-01').outputs.datafactoryId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-10-01').outputs.datafactoryId.value]"
                   },
                   "databricksId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-06-01').outputs.databricksId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-10-01').outputs.databricksId.value]"
                   }
                 },
                 "template": {
@@ -6100,8 +6174,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "3798967156873548985"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "5805240930503645364"
                     }
                   },
                   "parameters": {
@@ -6112,7 +6186,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "databricksName": "[if(greaterOrEquals(length(split(parameters('databricksId'), '/')), 9), last(split(parameters('databricksId'), '/')), 'incorrectSegmentLength')]",
                     "datafactorySubscriptionId": "[if(greaterOrEquals(length(split(parameters('datafactoryId'), '/')), 9), split(parameters('datafactoryId'), '/')[2], subscription().subscriptionId)]",
@@ -6143,15 +6216,15 @@
           "outputs": {
             "datafactoryIntegration001Id": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-06-01').outputs.datafactoryId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'datafactoryIntegration001'), '2020-10-01').outputs.datafactoryId.value]"
             },
             "databricksIntegration001Id": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-06-01').outputs.databricksId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-10-01').outputs.databricksId.value]"
             },
             "databricksIntegration001ApiUrl": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-06-01').outputs.databricksApiUrl.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksIntegration001'), '2020-10-01').outputs.databricksApiUrl.value]"
             }
           }
         }
@@ -6165,7 +6238,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "sharedProductServices",
       "resourceGroup": "[format('{0}-shared-product', variables('name'))]",
       "properties": {
@@ -6184,16 +6257,16 @@
             "value": "[variables('tagsJoined')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.servicesSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.servicesSubnetId.value]"
           },
           "vnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.vnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.vnetId.value]"
           },
           "databricksProduct001PrivateSubnetName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.databricksProductPrivateSubnetName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.databricksProductPrivateSubnetName.value]"
           },
           "databricksProduct001PublicSubnetName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.databricksProductPublicSubnetName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.databricksProductPublicSubnetName.value]"
           },
           "administratorUsername": {
             "value": "[variables('administratorUsername')]"
@@ -6202,7 +6275,7 @@
             "value": "[parameters('administratorPassword')]"
           },
           "synapseProduct001DefaultStorageAccountFileSystemId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-06-01').outputs.storageWorkspaceFileSystemId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-storage', variables('name'))), 'Microsoft.Resources/deployments', 'storageServices'), '2020-10-01').outputs.storageWorkspaceFileSystemId.value]"
           },
           "synapseSqlAdminGroupName": {
             "value": ""
@@ -6229,8 +6302,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "9345433290464409397"
+              "version": "0.4.1124.51302",
+              "templateHash": "15409668084215552802"
             }
           },
           "parameters": {
@@ -6290,7 +6363,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "variables": {
             "synapseProduct001DefaultStorageAccountSubscriptionId": "[if(greaterOrEquals(length(split(parameters('synapseProduct001DefaultStorageAccountFileSystemId'), '/')), 13), split(parameters('synapseProduct001DefaultStorageAccountFileSystemId'), '/')[2], subscription().subscriptionId)]",
             "synapseProduct001DefaultStorageAccountResourceGroupName": "[if(greaterOrEquals(length(split(parameters('synapseProduct001DefaultStorageAccountFileSystemId'), '/')), 13), split(parameters('synapseProduct001DefaultStorageAccountFileSystemId'), '/')[4], resourceGroup().name)]",
@@ -6300,7 +6372,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "databricksProduct001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -6333,8 +6405,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "7120584334142234558"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "4105412995154385767"
                     }
                   },
                   "parameters": {
@@ -6357,7 +6429,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Databricks/workspaces",
@@ -6412,7 +6483,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "synapseProduct001",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -6466,8 +6537,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "13357236325597900129"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "17554579698894687853"
                     }
                   },
                   "parameters": {
@@ -6518,7 +6589,6 @@
                       "defaultValue": ""
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "synapseDefaultStorageAccountFileSystemName": "[if(greaterOrEquals(length(split(parameters('synapseDefaultStorageAccountFileSystemId'), '/')), 13), last(split(parameters('synapseDefaultStorageAccountFileSystemId'), '/')), 'incorrectSegmentLength')]",
                     "synapseDefaultStorageAccountName": "[if(greaterOrEquals(length(split(parameters('synapseDefaultStorageAccountFileSystemId'), '/')), 13), split(parameters('synapseDefaultStorageAccountFileSystemId'), '/')[8], 'incorrectSegmentLength')]",
@@ -6740,7 +6810,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-06-01",
+              "apiVersion": "2020-10-01",
               "name": "synapse001StorageRoleAssignment",
               "subscriptionId": "[variables('synapseProduct001DefaultStorageAccountSubscriptionId')]",
               "resourceGroup": "[variables('synapseProduct001DefaultStorageAccountResourceGroupName')]",
@@ -6754,7 +6824,7 @@
                     "value": "[parameters('synapseProduct001DefaultStorageAccountFileSystemId')]"
                   },
                   "synapseId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'synapseProduct001'), '2020-06-01').outputs.synapseId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'synapseProduct001'), '2020-10-01').outputs.synapseId.value]"
                   }
                 },
                 "template": {
@@ -6763,8 +6833,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1008.15138",
-                      "templateHash": "8111279719426381349"
+                      "version": "0.4.1124.51302",
+                      "templateHash": "9115147018365543469"
                     }
                   },
                   "parameters": {
@@ -6775,7 +6845,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "storageAccountFileSystemName": "[if(greaterOrEquals(length(split(parameters('storageAccountFileSystemId'), '/')), 13), last(split(parameters('storageAccountFileSystemId'), '/')), 'incorrectSegmentLength')]",
                     "storageAccountName": "[if(greaterOrEquals(length(split(parameters('storageAccountFileSystemId'), '/')), 13), split(parameters('storageAccountFileSystemId'), '/')[8], 'incorrectSegmentLength')]",
@@ -6806,11 +6875,11 @@
           "outputs": {
             "databricksProduct001Id": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksProduct001'), '2020-06-01').outputs.databricksId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksProduct001'), '2020-10-01').outputs.databricksId.value]"
             },
             "databricksProduct001ApiUrl": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksProduct001'), '2020-06-01').outputs.databricksApiUrl.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'databricksProduct001'), '2020-10-01').outputs.databricksApiUrl.value]"
             }
           }
         }
@@ -6824,7 +6893,7 @@
     {
       "condition": "[not(empty(parameters('purviewId')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "purviewSubscriptionRoleAssignmentReader",
       "location": "[deployment().location]",
       "properties": {
@@ -6846,8 +6915,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "10665117672434887879"
+              "version": "0.4.1124.51302",
+              "templateHash": "279381183769349008"
             }
           },
           "parameters": {
@@ -6862,7 +6931,6 @@
               ]
             }
           },
-          "functions": [],
           "variables": {
             "purviewSubscriptionId": "[if(greaterOrEquals(length(split(parameters('purviewId'), '/')), 9), split(parameters('purviewId'), '/')[2], subscription().subscriptionId)]",
             "purviewResourceGroupName": "[if(greaterOrEquals(length(split(parameters('purviewId'), '/')), 9), split(parameters('purviewId'), '/')[4], 'incorrectSegmentLength')]",
@@ -6890,7 +6958,7 @@
     {
       "condition": "[not(empty(parameters('purviewId')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-10-01",
       "name": "purviewSubscriptionRoleAssignmentStorageBlobReader",
       "location": "[deployment().location]",
       "properties": {
@@ -6912,8 +6980,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1008.15138",
-              "templateHash": "10665117672434887879"
+              "version": "0.4.1124.51302",
+              "templateHash": "279381183769349008"
             }
           },
           "parameters": {
@@ -6928,7 +6996,6 @@
               ]
             }
           },
-          "functions": [],
           "variables": {
             "purviewSubscriptionId": "[if(greaterOrEquals(length(split(parameters('purviewId'), '/')), 9), split(parameters('purviewId'), '/')[2], subscription().subscriptionId)]",
             "purviewResourceGroupName": "[if(greaterOrEquals(length(split(parameters('purviewId'), '/')), 9), split(parameters('purviewId'), '/')[4], 'incorrectSegmentLength')]",
@@ -6957,95 +7024,95 @@
   "outputs": {
     "vnetId": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.vnetId.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.vnetId.value]"
     },
     "nsgId": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.nsgId.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.nsgId.value]"
     },
     "routeTableId": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.routeTableId.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-network', variables('name'))), 'Microsoft.Resources/deployments', 'networkServices'), '2020-10-01').outputs.routeTableId.value]"
     },
     "mySqlServer001SubscriptionId": {
       "type": "string",
-      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.mySqlServer001Id.value, '/')[2]]"
+      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.mySqlServer001Id.value, '/')[2]]"
     },
     "mySqlServer001ResourceGroupName": {
       "type": "string",
-      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.mySqlServer001Id.value, '/')[4]]"
+      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.mySqlServer001Id.value, '/')[4]]"
     },
     "mySqlServer001Name": {
       "type": "string",
-      "value": "[last(split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.mySqlServer001Id.value, '/'))]"
+      "value": "[last(split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.mySqlServer001Id.value, '/'))]"
     },
     "mySqlServer001KeyVaultid": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.keyVault001Id.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.keyVault001Id.value]"
     },
     "mySqlServer001UsernameSecretName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.mySqlServer001UsernameSecretName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.mySqlServer001UsernameSecretName.value]"
     },
     "mySqlServer001PasswordSecretName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.mySqlServer001PasswordSecretName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.mySqlServer001PasswordSecretName.value]"
     },
     "mySqlServer001ConnectionStringSecretName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-06-01').outputs.mySqlServer001ConnectionStringSecretName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-metadata', variables('name'))), 'Microsoft.Resources/deployments', 'metadataServices'), '2020-10-01').outputs.mySqlServer001ConnectionStringSecretName.value]"
     },
     "logAnalyticsWorkspaceKeyVaultId": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-logging', variables('name'))), 'Microsoft.Resources/deployments', 'loggingServices'), '2020-06-01').outputs.logAnalytics001WorkspaceKeyVaultId.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-logging', variables('name'))), 'Microsoft.Resources/deployments', 'loggingServices'), '2020-10-01').outputs.logAnalytics001WorkspaceKeyVaultId.value]"
     },
     "logAnalyticsWorkspaceIdSecretName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-logging', variables('name'))), 'Microsoft.Resources/deployments', 'loggingServices'), '2020-06-01').outputs.logAnalytics001WorkspaceIdSecretName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-logging', variables('name'))), 'Microsoft.Resources/deployments', 'loggingServices'), '2020-10-01').outputs.logAnalytics001WorkspaceIdSecretName.value]"
     },
     "logAnalyticsWorkspaceKeySecretName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-logging', variables('name'))), 'Microsoft.Resources/deployments', 'loggingServices'), '2020-06-01').outputs.logAnalytics001WorkspaceKeySecretName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-logging', variables('name'))), 'Microsoft.Resources/deployments', 'loggingServices'), '2020-10-01').outputs.logAnalytics001WorkspaceKeySecretName.value]"
     },
     "databricksIntegration001ApiUrl": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-06-01').outputs.databricksIntegration001ApiUrl.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-10-01').outputs.databricksIntegration001ApiUrl.value]"
     },
     "databricksIntegration001Id": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-06-01').outputs.databricksIntegration001Id.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-10-01').outputs.databricksIntegration001Id.value]"
     },
     "databricksIntegration001SubscriptionId": {
       "type": "string",
-      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-06-01').outputs.databricksIntegration001Id.value, '/')[2]]"
+      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-10-01').outputs.databricksIntegration001Id.value, '/')[2]]"
     },
     "databricksIntegration001ResourceGroupName": {
       "type": "string",
-      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-06-01').outputs.databricksIntegration001Id.value, '/')[4]]"
+      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-10-01').outputs.databricksIntegration001Id.value, '/')[4]]"
     },
     "databricksIntegration001Name": {
       "type": "string",
-      "value": "[last(split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-06-01').outputs.databricksIntegration001Id.value, '/'))]"
+      "value": "[last(split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-integration', variables('name'))), 'Microsoft.Resources/deployments', 'sharedIntegrationServices'), '2020-10-01').outputs.databricksIntegration001Id.value, '/'))]"
     },
     "databricksProduct001ApiUrl": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-06-01').outputs.databricksProduct001ApiUrl.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-10-01').outputs.databricksProduct001ApiUrl.value]"
     },
     "databricksProduct001Id": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-06-01').outputs.databricksProduct001Id.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-10-01').outputs.databricksProduct001Id.value]"
     },
     "databricksProduct001SubscriptionId": {
       "type": "string",
-      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-06-01').outputs.databricksProduct001Id.value, '/')[2]]"
+      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-10-01').outputs.databricksProduct001Id.value, '/')[2]]"
     },
     "databricksProduct001ResourceGroupName": {
       "type": "string",
-      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-06-01').outputs.databricksProduct001Id.value, '/')[4]]"
+      "value": "[split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-10-01').outputs.databricksProduct001Id.value, '/')[4]]"
     },
     "databricksProduct001Name": {
       "type": "string",
-      "value": "[last(split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-06-01').outputs.databricksProduct001Id.value, '/'))]"
+      "value": "[last(split(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-product', variables('name'))), 'Microsoft.Resources/deployments', 'sharedProductServices'), '2020-10-01').outputs.databricksProduct001Id.value, '/'))]"
     }
   }
 }

--- a/infra/modules/externalstorage.bicep
+++ b/infra/modules/externalstorage.bicep
@@ -12,6 +12,7 @@ param tags object
 param subnetId string
 param purviewId string = ''
 param privateDnsZoneIdBlob string = ''
+param dataLandingZoneSubscriptionIds array = []
 
 // Variables
 var storageExternal001Name = '${prefix}-ext001'
@@ -31,6 +32,7 @@ module storageExternal001 'services/externalstorage.bicep' = {
     privateDnsZoneIdBlob: privateDnsZoneIdBlob
     fileSytemNames: fileSytemNames
     purviewId: purviewId
+    dataLandingZoneSubscriptionIds: dataLandingZoneSubscriptionIds
   }
 }
 

--- a/infra/modules/metadata.bicep
+++ b/infra/modules/metadata.bicep
@@ -135,5 +135,6 @@ output sqlServer001Id string = sqlServer001.outputs.sqlServerId
 output sqlServer001DatabaseName string = sqlServer001.outputs.sqlServerDatabaseName
 output mySqlServer001Id string = mySqlServer001.outputs.mySqlServerId
 output mySqlServer001UsernameSecretName string = mySqlServer001UsernameSecretName
+#disable-next-line outputs-should-not-contain-secrets
 output mySqlServer001PasswordSecretName string = mySqlServer001PasswordSecretName
 output mySqlServer001ConnectionStringSecretName string = mySqlServer001ConnectionStringSecretName 

--- a/infra/modules/runtimes.bicep
+++ b/infra/modules/runtimes.bicep
@@ -53,9 +53,6 @@ resource datafactoryRuntimes001IntegrationRuntime001 'Microsoft.DataFactory/fact
 
 module datafactoryRuntimes001SelfHostedIntegrationRuntime001 'services/selfHostedIntegrationRuntime.bicep' = if (deploySelfHostedIntegrationRuntimes) {
   name: 'datafactoryRuntimes001SelfHostedIntegrationRuntime001'
-  dependsOn: [
-    datafactoryRuntimes001IntegrationRuntime001
-  ]
   scope: resourceGroup()
   params: {
     location: location

--- a/infra/modules/services/datafactoryruntime.bicep
+++ b/infra/modules/services/datafactoryruntime.bicep
@@ -29,6 +29,7 @@ resource datafactory 'Microsoft.DataFactory/factories@2018-06-01' = {
   properties: {
     globalParameters: {}
     publicNetworkAccess: 'Disabled'
+    #disable-next-line BCP037
     purviewConfiguration: {
       purviewResourceId: purviewId
     }

--- a/infra/modules/services/datafactorysharedintegration.bicep
+++ b/infra/modules/services/datafactorysharedintegration.bicep
@@ -44,6 +44,7 @@ resource datafactory 'Microsoft.DataFactory/factories@2018-06-01' = {
   properties: {
     globalParameters: {}
     publicNetworkAccess: 'Disabled'
+    #disable-next-line BCP037
     purviewConfiguration: {
       purviewResourceId: purviewId
     }

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -13,6 +13,7 @@ param subnetId string
 param purviewId string = ''
 param privateDnsZoneIdDfs string = ''
 param privateDnsZoneIdBlob string = ''
+param dataLandingZoneSubscriptionIds array = []
 
 // Variables
 var storageRawName = '${prefix}-raw'
@@ -42,6 +43,7 @@ module storageRaw 'services/storage.bicep' = {
     privateDnsZoneIdDfs: privateDnsZoneIdDfs
     fileSystemNames: domainFileSytemNames
     purviewId: purviewId
+    dataLandingZoneSubscriptionIds: dataLandingZoneSubscriptionIds
   }
 }
 
@@ -57,6 +59,7 @@ module storageEnrichedCurated 'services/storage.bicep' = {
     privateDnsZoneIdDfs: privateDnsZoneIdDfs
     fileSystemNames: domainFileSytemNames
     purviewId: purviewId
+    dataLandingZoneSubscriptionIds: dataLandingZoneSubscriptionIds
   }
 }
 
@@ -72,6 +75,7 @@ module storageWorkspace 'services/storage.bicep' = {
     privateDnsZoneIdDfs: privateDnsZoneIdDfs
     fileSystemNames: dataProductFileSystemNames
     purviewId: purviewId
+    dataLandingZoneSubscriptionIds: dataLandingZoneSubscriptionIds
   }
 }
 

--- a/infra/params.dev.json
+++ b/infra/params.dev.json
@@ -76,6 +76,9 @@
         "deploySelfHostedIntegrationRuntimes": {
             "value": true
         },
+        "dataLandingZoneSubscriptionIds": {
+            "value": []
+        },
         "privateDnsZoneIdKeyVault": {
             "value": "/subscriptions/17588eb2-2943-461a-ab3f-00a3ceac3112/resourceGroups/dmz-dev-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
         },

--- a/infra/params.prod.json
+++ b/infra/params.prod.json
@@ -76,6 +76,9 @@
         "deploySelfHostedIntegrationRuntimes": {
             "value": true
         },
+        "dataLandingZoneSubscriptionIds": {
+            "value": []
+        },
         "privateDnsZoneIdKeyVault": {
             "value": "/subscriptions/17588eb2-2943-461a-ab3f-00a3ceac3112/resourceGroups/dmz-prd-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
         },

--- a/infra/params.test.json
+++ b/infra/params.test.json
@@ -76,6 +76,9 @@
         "deploySelfHostedIntegrationRuntimes": {
             "value": true
         },
+        "dataLandingZoneSubscriptionIds": {
+            "value": []
+        },
         "privateDnsZoneIdKeyVault": {
             "value": "/subscriptions/17588eb2-2943-461a-ab3f-00a3ceac3112/resourceGroups/dmz-tst-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
         },


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds resource rules for all Data Landing Zone subcriptions to the Data Lakes. This allows cross-Data Landing Zone data access using SQL Pools and SQL serverless within DMA. It also fixes a few Bicep linting issues.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? -->
## References
None

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes Issue https://github.com/Azure/data-landing-zone/issues/219
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
See comments and runs below.